### PR TITLE
Added support for multiple domainFilters in externalDNS

### DIFF
--- a/templates/external-dns.yaml.tpl
+++ b/templates/external-dns.yaml.tpl
@@ -8,12 +8,15 @@ aws:
   region: eu-west-2
   zoneType: public
 domainFilters:
-  ${domainFilters}
+%{ for d in domainFilters ~}
+  - ${d}
+%{ endfor ~}
 rbac:
   create: true
   apiVersion: v1
   serviceAccountName: default
 txtPrefix: "_external_dns."
+txtOwnerId: ${cluster}
 logLevel: info
 podAnnotations:
   iam.amazonaws.com/role: "${iam_role}"

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,17 @@ variable "enable_opa" {
   type        = bool
   default     = true
 }
+
+variable "cluster_r53_resource_maps" {
+  default = {
+    live-1 = [ "arn:aws:route53:::hostedzone/*" ] 
+    manager = [ "arn:aws:route53:::hostedzone/Z1OWR28V4Q2RTU", "arn:aws:route53:::hostedzone/Z1OWR28V4Q2RTU" ]
+  }
+}
+
+variable "cluster_r53_domainfilters" {
+  default = {
+    live-1 = [ "*" ] 
+    manager = [ "manager.cloud-platform.service.justice.gov.uk.", "cloud-platform.service.justice.gov.uk." ]
+  }
+}


### PR DESCRIPTION
We need out EKS cluster (concourse manager) be able to create A records in the main CP hostzone. It means it needs to live together with the live-1's externalDNS. 

This PR allow configuration of multiple domain filters and multiple Hostzones in the Policy document (for IAM)
