### PR TITLE
New variables to support multiclustering

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -125,10 +125,7 @@ resource "aws_iam_role" "cert_manager" {
 data "aws_iam_policy_document" "cert_manager" {
   statement {
     actions = ["route53:ChangeResourceRecordSets"]
-    resources = [format(
-      "arn:aws:route53:::hostedzone/%s",
-      terraform.workspace == local.live_workspace ? "*" : data.aws_route53_zone.selected.zone_id,
-    )]
+    resources = lookup(var.cluster_r53_resource_maps, terraform.workspace, [ "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}" ] ) 
   }
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "enable_opa" {
 variable "cluster_r53_resource_maps" {
   default = {
     live-1 = [ "arn:aws:route53:::hostedzone/*" ] 
-    manager = [ "arn:aws:route53:::hostedzone/Z1OWR28V4Q2RTU", "arn:aws:route53:::hostedzone/Z1OWR28V4Q2RTU" ]
+    manager = [ "arn:aws:route53:::hostedzone/Z1OWR28V4Q2RTU", "arn:aws:route53:::hostedzone/Z22YRW76GPFC1M" ]
   }
 }
 


### PR DESCRIPTION
It was added `cluster_r53_resource_maps` terraform variable in order to support multiple hostzones for external-dns/cert-manager