### PR TITLE
Updated ingresses

### DIFF
--- a/prometheus.tf
+++ b/prometheus.tf
@@ -93,10 +93,10 @@ EOS
 }
 
 locals {
-  alertmanager_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "https://alertmanager", local.live_domain) : format("%s.%s", "https://alertmanager.apps", data.terraform_remote_state.cluster.outputs.cluster_domain_name)
-  grafana_ingress      = terraform.workspace == local.live_workspace ? format("%s.%s", "grafana", local.live_domain) : format("%s.%s", "grafana.apps", data.terraform_remote_state.cluster.outputs.cluster_domain_name)
-  grafana_root         = terraform.workspace == local.live_workspace ? format("%s.%s", "https://grafana", local.live_domain) : format("%s.%s", "https://grafana.apps", data.terraform_remote_state.cluster.outputs.cluster_domain_name)
-  prometheus_ingress   = terraform.workspace == local.live_workspace ? format("%s.%s", "https://prometheus", local.live_domain) : format("%s.%s", "https://prometheus.apps", data.terraform_remote_state.cluster.outputs.cluster_domain_name)
+  alertmanager_ingress = format("%s.%s", "https://alertmanager.apps", data.terraform_remote_state.cluster.outputs.cluster_domain_name)
+  grafana_ingress      = format("%s.%s", "grafana.apps", data.terraform_remote_state.cluster.outputs.cluster_domain_name)
+  grafana_root         = format("%s.%s", "https://grafana.apps", data.terraform_remote_state.cluster.outputs.cluster_domain_name)
+  prometheus_ingress   = format("%s.%s", "https://prometheus.apps", data.terraform_remote_state.cluster.outputs.cluster_domain_name)
 }
 
 resource "helm_release" "prometheus_operator" {

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -186,6 +186,11 @@ grafana:
       enabled: true
       label: grafana_datasource
 
+prometheus:
+  enabled: true
+
+  prometheusSpec:
+    externalUrl: "${ prometheus_ingress }"
 
 defaultRules:
   rules:


### PR DESCRIPTION
Updated ingresses with non-live URL for all EKS cluster