### PR TITLE
Fix broken hostzone variable in external-dns

### DIFF
--- a/external-dns.tf
+++ b/external-dns.tf
@@ -3,7 +3,7 @@ module "external_dns" {
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, [data.aws_route53_zone.selected.zone_id])
+  hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}"])
 
   # EKS doesn't use KIAM but it is a requirement for the module.
   dependence_kiam   = ""


### PR DESCRIPTION
This was referencing an incorrect list, which was causing an incorrect interpolation. This PR fixes that reference.